### PR TITLE
Allow window ADFS automatic login for windows

### DIFF
--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -96,7 +96,7 @@ class SAMLConfiguration extends Object {
 			// Set true or don't present thi parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'
 			// Set an array with the possible auth context values: array ('urn:oasis:names:tc:SAML:2.0:ac:classes:Password', 'urn:oasis:names:tc:SAML:2.0:ac:classes:X509'),
 			'requestedAuthnContext' => array(
-				// 'urn:federation:authentication:windows',
+				'urn:federation:authentication:windows',
 				'urn:oasis:names:tc:SAML:2.0:ac:classes:Password',
 				'urn:oasis:names:tc:SAML:2.0:ac:classes:X509',
 			),


### PR DESCRIPTION
This will make the login and redirect to ADFS transparent for the user. It requires that the ADFS site is added to the internet explorers zone for Intranet sites and that the Windows Autologin. Example of setup can be found here https://confluence.atlassian.com/display/SPCON/Setting+your+Browser+Options+for+Automatic+Login
