### PR TITLE
Fix tests when running in a projects with other member/group extensions

### DIFF
--- a/code/model/LDAPGateway.php
+++ b/code/model/LDAPGateway.php
@@ -20,6 +20,7 @@ class LDAPGateway extends Object
 
     public function __construct()
     {
+        parent::__construct();
         $this->ldap = new Zend\Ldap\Ldap($this->config()->options);
     }
 

--- a/code/services/LDAPService.php
+++ b/code/services/LDAPService.php
@@ -104,6 +104,8 @@ class LDAPService extends Object implements Flushable
      *
      * @param string $username
      * @param string $password
+     *
+     * @return array
      */
     public function authenticate($username, $password)
     {
@@ -158,7 +160,7 @@ class LDAPService extends Object implements Flushable
      * @param boolean $cached Cache the results from AD, so that subsequent calls are faster. Enabled by default.
      * @param array $attributes List of specific AD attributes to return. Empty array means return everything.
      * @param string $indexBy Attribute to use as an index.
-     * @return associative array
+     * @return array
      */
     public function getGroups($cached = true, $attributes = array(), $indexBy = 'dn')
     {
@@ -233,7 +235,7 @@ class LDAPService extends Object implements Flushable
     /**
      * Get a particular AD group's data given a DN.
      *
-     * @param string $guid
+     * @param string $dn
      * @param array $attributes List of specific AD attributes to return. Empty array means return everything.
      * @return array
      */
@@ -296,8 +298,9 @@ class LDAPService extends Object implements Flushable
     /**
      * Get a specific AD user's data given a DN.
      *
-     * @param string $guid
+     * @param string $dn
      * @param array $attributes List of specific AD attributes to return. Empty array means return everything.
+     *
      * @return array
      */
     public function getUserByDN($dn, $attributes = array())
@@ -537,6 +540,8 @@ class LDAPService extends Object implements Flushable
      *
      * @param Group $group An existing Group or a new Group object
      * @param array $data LDAP group object data
+     *
+     * @return bool
      */
     public function updateGroupFromLDAP(Group $group, $data)
     {

--- a/tests/LDAPServiceTest.php
+++ b/tests/LDAPServiceTest.php
@@ -20,6 +20,11 @@ class LDAPServiceTest extends SapphireTest
             'CN=Users,DC=playpen,DC=local',
             'CN=Others,DC=playpen,DC=local'
         ));
+        // Prevent other module extension hooks from executing during write() etc.
+        Config::inst()->remove('Member', 'extensions');
+        Config::inst()->remove('Group', 'extensions');
+        Config::inst()->update('Group', 'extensions', array('LDAPGroupExtension'));
+        Config::inst()->update('Member', 'extensions', array('LDAPMemberExtension'));
     }
 
     public function tearDown()

--- a/tests/LDAPServiceTest.php
+++ b/tests/LDAPServiceTest.php
@@ -1,6 +1,10 @@
 <?php
 class LDAPServiceTest extends SapphireTest
 {
+
+    /**
+     * @var LDAPService
+     */
     protected $service;
 
     public function setUp()

--- a/tests/model/LDAPFakeGateway.php
+++ b/tests/model/LDAPFakeGateway.php
@@ -1,5 +1,5 @@
 <?php
-class LDAPFakeGateway extends LDAPGateway
+class LDAPFakeGateway extends LDAPGateway implements TestOnly
 {
     public function __construct()
     {


### PR DESCRIPTION
This can happens when the LDAP options haven't been set, for example during automated testing.
