### PR TITLE
Switch the default SAML signing algorithm to SHA-256

### DIFF
--- a/_config/saml.yml
+++ b/_config/saml.yml
@@ -23,3 +23,10 @@ SAMLAuthenticator:
 SAMLConfiguration:
   strict: true
   debug: false
+  Security:
+    # Algorithm that the toolkit will use on signing process. Options:
+    #  - 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+    #  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+    #  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
+    #  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
+    signatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"

--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -73,6 +73,9 @@ class SAMLConfiguration extends Object
         $conf['idp']['x509cert'] = file_get_contents($idpCertPath);
 
         // SECURITY SECTION
+        $security = $this->config()->get('Security');
+        $signatureAlgorithm = $security['signatureAlgorithm'];
+
         $conf['security'] = array(
             /** signatures and encryptions offered */
             // Indicates that the nameID of the <samlp:logoutRequest> sent by this SP will be encrypted.
@@ -94,6 +97,15 @@ class SAMLConfiguration extends Object
             // Indicates a requirement for the NameID received by
             // this SP to be encrypted.
             'wantNameIdEncrypted' => false,
+
+            // Algorithm that the toolkit will use on signing process. Options:
+            //  - 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+            //  - 'http://www.w3.org/2000/09/xmldsig#dsa-sha1'
+            //  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'
+            //  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha384'
+            //  - 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512'
+            'signatureAlgorithm' => $signatureAlgorithm,
+
             // Authentication context.
             // Set to false and no AuthContext will be sent in the AuthNRequest,
             // Set true or don't present thi parameter and you will get an AuthContext 'exact' 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport'

--- a/docs/en/adfs.md
+++ b/docs/en/adfs.md
@@ -96,7 +96,7 @@ Note that the "privatepersonalidentifier" must be a unique identifier (we will r
 Click "Add Rule" and select "Send Claims Using a Custom Rule" from the dropdown. Add the following rule:
 
 	c:[Type == "http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname", Issuer == "AD AUTHORITY"] => issue(store = "Active Directory", types = ("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/givenname", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname", "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/privatepersonalidentifier"), query = ";mail,givenName,sn,objectGuid;{0}", param = c.Value);
-	
+
 ![](img/send_ldap_attributes.png)
 
 ### Rule 2: Send objectId as nameidentifier
@@ -109,7 +109,10 @@ Repeat the same "Add Rule" as done above and select "Send Claims Using a Custom 
 
 ## Set the secure hash algorithm
 
-By default ADFS uses a hash algorithm incompatible with *silverstripe-activedirectory* SAML implementation. You will need to change it from SHA-256 to SHA-1.
+By default ADFS uses SHA-256 for signing the requests, the Active Directory
+module by default uses this hash algorithm, but can be changed to use the less
+secure SHA-1. The only reason should be changed is for compatibility with the
+setting used by the SilverStripe site. Here is how to change it:
 
 1. Right click the relying party and choose properties.
 2. Choose the "Advanced" tab and select the "SHA-1" option in the dropdown and press OK.

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -48,7 +48,7 @@ We assume ADFS 2.0 or greater is used as an IdP.
 First step is to add this module into your SilverStripe project. You can use composer for this:
 
 	composer require "silverstripe/activedirectory:*"
-	
+
 Commit the changes.
 
 ## Make x509 certificates available
@@ -62,7 +62,7 @@ You need to make the SP x509 certificate and private key available to the Silver
 For testing purposes, you can generate this yourself by using the `openssl` command:
 
 	openssl req -x509 -nodes -newkey rsa:2048 -keyout saml.pem -out saml.crt -days 1826
-	
+
 Contact your system administrator if you are not sure how to install these.
 
 ### IdP certificate
@@ -75,7 +75,7 @@ You may also be able to extract the certificate yourself from the IdP endpoint i
 
 ## YAML configuration
 
-Now we need to make the *silverstripe-activedirectory* module aware of where the certificates can be found. 
+Now we need to make the *silverstripe-activedirectory* module aware of where the certificates can be found.
 
 Add the following configuration to `mysite/_config/saml.yml` (make sure to replace paths to the certificates and keys):
 
@@ -95,10 +95,22 @@ Add the following configuration to `mysite/_config/saml.yml` (make sure to repla
 	    entityId: "https://<idp-domain>/adfs/services/trust"
 	    x509cert: "<path-to-adfs-cert>.pem"
 	    singleSignOnService: "https://<idp-domain>/adfs/ls/"
+	  Security:
+	    signatureAlgorithm: "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256"
 
 If you don't use absolute paths, the certificate paths will be relative to the `BASE_PATH` (your site web root).
 
 All IdP and SP endpoints must use HTTPS scheme with SSL certificates matching the domain names used.
+
+### A note on signature algorithm config
+
+The signature algorithm must match the setting in the ADFS relying party trust
+configuration. For ADFS it's possible to downgrade the default from SHA-256 to
+ SHA-1, but this is not recommended. To do this, you can change YAML configuration:
+
+	SAMLConfiguration:
+	  Security:
+	    signatureAlgorithm: "http://www.w3.org/2000/09/xmldsig#rsa-sha1"
 
 ### Service Provider (SP)
 
@@ -382,9 +394,9 @@ ldapsearch \
 ## Advanced SAML configuration
 
 It is possible to customize all the settings provided by the 3rd party SAML code.
- 
+
 This can be done by registering your own `SAMLConfiguration` object via `mysite/_config/saml.yml`:
- 
+
 Example:
 
 	---


### PR DESCRIPTION
This module will now use the SHA-256 hash algorithm instead of the SHA-1 algorithm.
This will break currently running SilverStripe -> ADFS integration. The ADFS needs to
change the setting on the relying party trust.
