### PR TITLE
Fixes to username missing on syncing users with update_ldap_from_local

### DIFF
--- a/code/authenticators/LDAPAuthenticator.php
+++ b/code/authenticators/LDAPAuthenticator.php
@@ -104,8 +104,11 @@ class LDAPAuthenticator extends Authenticator
         if (!($member && $member->exists())) {
             $member = new Member();
             $member->GUID = $data['objectguid'];
-            $member->write();
         }
+
+        // Update the users from LDAP so we are sure that the email is correct.
+        // This will also write the Member record.
+        $service->updateMemberFromLDAP($member);
 
         Session::clear('BackURL');
 

--- a/code/authenticators/LDAPLoginForm.php
+++ b/code/authenticators/LDAPLoginForm.php
@@ -129,17 +129,17 @@ JS;
         if (!($member && $member->exists())) {
             $member = new Member();
             $member->GUID = $userData['objectguid'];
-            $member->write();
         }
+
+        // Update the users from LDAP so we are sure that the email is correct.
+        // This will also write the Member record.
+        $service->updateMemberFromLDAP($member);
 
         // Allow vetoing forgot password requests
         $results = $this->extend('forgotPassword', $member);
         if ($results && is_array($results) && in_array(false, $results, true)) {
             return $this->controller->redirect($this->ldapSecController->Link('lostpassword'));
         }
-
-        // update the users from LDAP so we are sure that the email is correct
-        $service->updateMemberFromLDAP($member);
 
         if ($member) {
             $token = $member->generateAutologinTokenAndStoreHash();

--- a/code/control/SAMLController.php
+++ b/code/control/SAMLController.php
@@ -95,11 +95,10 @@ class SAMLController extends Controller
 
         $member->SAMLSessionIndex = $auth->getSessionIndex();
 
-        // This will throw an exception if there are two distinct GUIDs with the same email address.
-        // We are happy with a raw 500 here at this stage.
-        $member->write();
-
         // This will trigger LDAP update through LDAPMemberExtension::memberLoggedIn.
+        // The LDAP update will also write the Member record. We shouldn't write before
+        // calling this, as any onAfterWrite hooks that attempt to update LDAP won't
+        // have the Username field available yet for new Member records, and fail.
         // Both SAML and LDAP identify Members by the GUID field.
         $member->logIn();
 

--- a/code/services/LDAPService.php
+++ b/code/services/LDAPService.php
@@ -675,6 +675,10 @@ class LDAPService extends Object implements Flushable
             throw new ValidationException('LDAP synchronisation failure: user missing GUID');
         }
 
+        if (empty($member->Username)) {
+            throw new ValidationException('Member missing Username. Cannot update LDAP user');
+        }
+
         $dn = $data['distinguishedname'];
 
         // Normalise username to lowercase to ensure we don't have duplicates of different cases

--- a/code/tasks/LDAPMemberSyncTask.php
+++ b/code/tasks/LDAPMemberSyncTask.php
@@ -45,11 +45,9 @@ class LDAPMemberSyncTask extends BuildTask
                 // create the initial Member with some internal fields
                 $member = new Member();
                 $member->GUID = $data['objectguid'];
-                $member->write();
 
                 $this->log(sprintf(
-                    'Creating new Member (ID: %s, GUID: %s, sAMAccountName: %s)',
-                    $member->ID,
+                    'Creating new Member (GUID: %s, sAMAccountName: %s)',
                     $data['objectguid'],
                     $data['samaccountname']
                 ));
@@ -63,7 +61,7 @@ class LDAPMemberSyncTask extends BuildTask
                 ));
             }
 
-            // sync attributes from LDAP to the Member record
+            // Sync attributes from LDAP to the Member record. This will also write the Member record.
             // this is also responsible for putting the user into mapped groups
             try {
                 $this->ldapService->updateMemberFromLDAP($member, $data);


### PR DESCRIPTION
Username is required, otherwise Member::onAfterWrite() hooks that
attempt to use the Username field on new Member records with a GUID
but no Username will fail. Ensure that we update the Member record from
LDAP which loads in mapped attributes before calling write itself.
