### PR TITLE
Add support for user-configurable NameID format.

### DIFF
--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -51,7 +51,7 @@ class SAMLConfiguration extends Object
             'url' => $sp['entityId'] . '/saml/acs',
             'binding' => OneLogin_Saml2_Constants::BINDING_HTTP_POST
         ];
-        $conf['sp']['NameIDFormat'] = OneLogin_Saml2_Constants::NAMEID_TRANSIENT;
+        $conf['sp']['NameIDFormat'] = isset($sp['nameIdFormat') ? $sp['nameIdFormat'] : OneLogin_Saml2_Constants::NAMEID_TRANSIENT;
         $conf['sp']['x509cert'] = file_get_contents($spCertPath);
         $conf['sp']['privateKey'] = file_get_contents($spKeyPath);
 

--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -51,7 +51,7 @@ class SAMLConfiguration extends Object
             'url' => $sp['entityId'] . '/saml/acs',
             'binding' => OneLogin_Saml2_Constants::BINDING_HTTP_POST
         ];
-        $conf['sp']['NameIDFormat'] = isset($sp['nameIdFormat') ? $sp['nameIdFormat'] : OneLogin_Saml2_Constants::NAMEID_TRANSIENT;
+        $conf['sp']['NameIDFormat'] = isset($sp['nameIdFormat']) ? $sp['nameIdFormat'] : OneLogin_Saml2_Constants::NAMEID_TRANSIENT;
         $conf['sp']['x509cert'] = file_get_contents($spCertPath);
         $conf['sp']['privateKey'] = file_get_contents($spKeyPath);
 


### PR DESCRIPTION
A small change to add support for specifying a custom NameID format in the YAML configuration file for this module. In so doing, this adds support for inter-operating with the Shibboleth Identity Provider software.

Documentation on Shibboleth IdP interoperability will be created on a separate PR, with instructions for both the SilverStripe and Shibboleth ends of the integration.