### PR TITLE
Set the baseurl to the SP URL to fix issues with onelogin upgrade

### DIFF
--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -44,6 +44,10 @@ class SAMLConfiguration extends Object
 
         // SERVICE PROVIDER SECTION
         $sp = $this->config()->get('SP');
+
+        // set baseurl for SAML messages coming back to the SP
+        $conf['baseurl'] = $sp['entityId'];
+
         $spCertPath = Director::is_absolute($sp['x509cert']) ? $sp['x509cert'] : sprintf('%s/%s', BASE_PATH, $sp['x509cert']);
         $spKeyPath = Director::is_absolute($sp['privateKey']) ? $sp['privateKey'] : sprintf('%s/%s', BASE_PATH, $sp['privateKey']);
         $conf['sp']['entityId'] = $sp['entityId'];

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "zendframework/zend-ldap": "2.5.1",
         "zendframework/zend-authentication": "2.5.1",
         "zendframework/zend-session": "2.5.1",
-        "onelogin/php-saml": "2.*@stable"
+        "onelogin/php-saml": "~2.10.0@stable"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
Fixes baseurl not set correctly, it tries to guess it and sometimes
fails to get the right protocol due to proxying of requests. Set it to
the SP URL.