### PR TITLE
Lock the version of PHP-SAML to 2.10.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "zendframework/zend-ldap": "2.5.1",
         "zendframework/zend-authentication": "2.5.1",
         "zendframework/zend-session": "2.5.1",
-        "onelogin/php-saml": "~2.10.0@stable"
+        "onelogin/php-saml": "2.10.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
Version 2.10.6 breaks the URL/Destination detection