### PR TITLE
Travis suite to test against actively developped versions of SS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ sudo: false
 matrix:
   include:
     - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.2
+      env: DB=MYSQL CORE_RELEASE=3.5
     - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.3
+      env: DB=MYSQL CORE_RELEASE=3.6
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.4
+      env: DB=MYSQL CORE_RELEASE=3
 
 before_install:
   - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini


### PR DESCRIPTION
3.2, 3.3 and 3.4 are now retired versions of SS. We should test against the latest in the 3 line instead.