### PR TITLE
Fix the base path to be as expected by the php-saml module.

### DIFF
--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -52,8 +52,8 @@ class SAMLConfiguration extends Object
         // SERVICE PROVIDER SECTION
         $sp = $this->config()->get('SP');
 
-        // set baseurl for SAML messages coming back to the SP
-        $conf['baseurl'] = $sp['entityId'];
+        // Set baseurl for SAML messages coming back to the SP
+        $conf['baseurl'] = sprintf('%s/saml', $sp['entityId']);
 
         $spCertPath = Director::is_absolute($sp['x509cert']) ? $sp['x509cert'] : sprintf('%s/%s', BASE_PATH, $sp['x509cert']);
         $spKeyPath = Director::is_absolute($sp['privateKey']) ? $sp['privateKey'] : sprintf('%s/%s', BASE_PATH, $sp['privateKey']);


### PR DESCRIPTION
The path "base" is just one level down from the endpoint, otherwise IdP
will try calling us back at "<base-url>/acs", instead of correct
"<base-url>/saml/acs"