### PR TITLE
pass array through to mapped function if needed

### DIFF
--- a/code/control/SAMLController.php
+++ b/code/control/SAMLController.php
@@ -90,7 +90,7 @@ class SAMLController extends Controller
                 continue;
             }
 
-            $member->$field = $attributes[$claim][0];
+            $member->$field = $attributes[$claim];
         }
 
         $member->SAMLSessionIndex = $auth->getSessionIndex();

--- a/code/control/SAMLController.php
+++ b/code/control/SAMLController.php
@@ -90,7 +90,11 @@ class SAMLController extends Controller
                 continue;
             }
 
-            $member->$field = $attributes[$claim];
+            if(is_array($attributes[$claim]) && count($attributes[$claim]) > 1) {
+                $member->$field = $attributes[$claim];
+            } else {
+                $member->$field = $attributes[$claim][0];
+            }
         }
 
         $member->SAMLSessionIndex = $auth->getSessionIndex();

--- a/code/control/SAMLController.php
+++ b/code/control/SAMLController.php
@@ -90,7 +90,7 @@ class SAMLController extends Controller
                 continue;
             }
 
-            if(is_array($attributes[$claim]) && count($attributes[$claim]) > 1) {
+            if(count($attributes[$claim]) > 1) {
                 $member->$field = $attributes[$claim];
             } else {
                 $member->$field = $attributes[$claim][0];

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "silverstripe/activedirectory",
+    "name": "zenril/activedirectory",
     "description": "Adds Active Directory support to SilverStripe including user synchronisation and SSO/LDAP authentication",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "ad", "active", "directory", "ldap", "sso", "saml"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "zenril/activedirectory",
+    "name": "silverstripe/activedirectory",
     "description": "Adds Active Directory support to SilverStripe including user synchronisation and SSO/LDAP authentication",
     "type": "silverstripe-module",
     "keywords": ["silverstripe", "ad", "active", "directory", "ldap", "sso", "saml"],


### PR DESCRIPTION
@NightJar Sorry about that.

A Member can belong to multiple AD Groups I guess.

When using the Group claim ('http://schemas.xmlsoap.org/claims/Group') in the claims_field_mapping, the values are an array.

[1] => SEC_WebsiteSignup_ADGroup1
[2] => SEC_WebsiteSignup_ADGroup2
[3] => SEC_WebsiteSignup_ADGroup3
[4] => SEC_WebsiteSignup_ADGroup4

The current functionality only passes the first AD Group value to the mapped function.