### PR TITLE
Add: possibility to use additional get-query parameters to SAML Request

### DIFF
--- a/code/authenticators/SAMLAuthenticator.php
+++ b/code/authenticators/SAMLAuthenticator.php
@@ -21,6 +21,14 @@ class SAMLAuthenticator extends Authenticator
     private $name = 'SAML';
 
     /**
+     * @example ['GET Query Parameter Name' => 'Parameter Value', ... ]
+     *
+     * @var string[]
+     * @config
+     */
+    private static $additional_get_query_params = [];
+
+    /**
      * @return string
      */
     public static function get_name()
@@ -51,8 +59,20 @@ class SAMLAuthenticator extends Authenticator
     {
         // $data is not used - the form is just one button, with no fields.
         $auth = Injector::inst()->get('SAMLHelper')->getSAMLAuth();
+        /** @var $auth \OneLogin_Saml2_Auth */
+
         Session::set('BackURL', isset($data['BackURL']) ? $data['BackURL'] : null);
         Session::save();
-        $auth->login(Director::absoluteBaseURL().'saml/');
+
+        $additionalGetQueryParams = SAMLAuthenticator::config()->get('additional_get_query_params');
+
+        if (!is_array($additionalGetQueryParams)) {
+            $additionalGetQueryParams = [];
+        }
+
+        $auth->login(
+            Director::absoluteBaseURL().'saml/',
+            $additionalGetQueryParams
+        );
     }
 }

--- a/docs/en/developer.md
+++ b/docs/en/developer.md
@@ -50,6 +50,7 @@ We assume ADFS 2.0 or greater is used as an IdP.
   - [Allowing users to update their AD password](#allowing-users-to-update-their-ad-password)
   - [Writing LDAP data from SilverStripe](#writing-ldap-data-from-silverstripe)
   - [Ensuring consistent response times](#ensuring-consistent-response-times)
+  - [Additional GET Query Params for SAML](#additional-get-query-params-for-saml)
 - [Resources](#resources)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -611,6 +612,18 @@ It is possible to figure out if a user exists in the database when sending a pas
 LDAPLoginForm:
   consistent_password_times: true
 ```
+
+### Additional GET Query Params for SAML
+example:
+```yaml
+SAMLAuthenticator:
+  additional_get_query_params:
+    someGetQueryParameter: 'value'
+    AnotherParameter: 'differentValue'
+```
+
+this configuration allows you to add two GET query parameters to endpoint request URL:
+`https://your-idp.com/singleSignOnService/saml2?someGetQueryParameter=value&AnotherParameter=differentValue&SAMLRequest=XYZ....`
 
 ## Resources
 


### PR DESCRIPTION
This configuration option allow use additional simple query parameters in Authentication request URL (handy for custom IdP configurations like helping with Home Realm Discovery and others)