### PR TITLE
Upgrade onelogin/php-saml to v3 to support PHP 7.1+ (WIP)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,23 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 matrix:
   include:
     - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.5
+      env: DB=MYSQL CORE_RELEASE=3.7
     - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.6
+      env: DB=MYSQL CORE_RELEASE=3.7
     - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.7
+    - php: 7.0
+      env: DB=MYSQL CORE_RELEASE=3
+    - php: 7.1
+      env: DB=MYSQL CORE_RELEASE=3
+    - php: 7.2
+      env: DB=PGSQL CORE_RELEASE=3
+    - php: 7.3
       env: DB=MYSQL CORE_RELEASE=3
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
     - php: 7.3
       env: DB=MYSQL CORE_RELEASE=3
 
-before_install:
-  - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
-
 before_script:
   - composer self-update || true
   - phpenv rehash

--- a/code/control/LDAPSecurityController.php
+++ b/code/control/LDAPSecurityController.php
@@ -42,7 +42,7 @@ class LDAPSecurityController extends Security
      */
     public function ChangePasswordForm()
     {
-        return Object::create('LDAPChangePasswordForm', $this, 'ChangePasswordForm');
+        return SS_Object::create('LDAPChangePasswordForm', $this, 'ChangePasswordForm');
     }
 
     public function lostpassword()

--- a/code/helpers/SAMLHelper.php
+++ b/code/helpers/SAMLHelper.php
@@ -5,7 +5,7 @@
  * SAMLHelper acts as a simple wrapper for the OneLogin implementation, so that we can configure
  * and inject it via the config system.
  */
-class SAMLHelper extends Object
+class SAMLHelper extends SS_Object
 {
     /**
      * @var array

--- a/code/model/LDAPGateway.php
+++ b/code/model/LDAPGateway.php
@@ -5,7 +5,7 @@
  * Works within the LDAP domain model to provide basic operations.
  * These are exclusively used in LDAPService for constructing more complex operations.
  */
-class LDAPGateway extends Object
+class LDAPGateway extends SS_Object
 {
     /**
      * @var array

--- a/code/services/LDAPService.php
+++ b/code/services/LDAPService.php
@@ -12,7 +12,7 @@
  *
  * LDAPService relies on Zend LDAP module's data structures for some parameters and some return values.
  */
-class LDAPService extends Object implements Flushable
+class LDAPService extends SS_Object implements Flushable
 {
     /**
      * @var array

--- a/code/services/SAMLConfiguration.php
+++ b/code/services/SAMLConfiguration.php
@@ -10,7 +10,7 @@
  *
  * https://syncplicity.zendesk.com/hc/en-us/articles/202392814-Single-sign-on-with-ADFS
  */
-class SAMLConfiguration extends Object
+class SAMLConfiguration extends SS_Object
 {
     /**
      * @var bool

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     ],
     "require": {
         "php": ">=5.4",
-        "silverstripe/framework": "~3.1",
+        "silverstripe/framework": "^3.7",
         "symbiote/silverstripe-queuedjobs": "^3",
         "zendframework/zend-ldap": "^2.5.1",
         "zendframework/zend-authentication": "^2.5.1",
         "zendframework/zend-session": "^2.5.1",
-        "onelogin/php-saml": "^2.10.7"
+        "onelogin/php-saml": "^3"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.8"


### PR DESCRIPTION
I've converted the module to use the latest version of `onelogin/php-saml` and SS3.7.

However I didn't manage to set up an active directory for testing. So I don't know for a fact that it works and the test coverage is patchy.

# Parent issue
* https://github.com/silverstripe/silverstripe-activedirectory/issues/128