### PR TITLE
Run tests on PHP 7.1 instead of PHP 5.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ language: php
 
 sudo: false
 
+services:
+  - mysql
+
 matrix:
   include:
-    - php: 5.4
-      env: DB=MYSQL CORE_RELEASE=3.5
-    - php: 5.5
-      env: DB=MYSQL CORE_RELEASE=3.6
-    - php: 5.6
+    - php: 7.1
       env: DB=MYSQL CORE_RELEASE=3
-
-before_install:
-  - echo "extension=ldap.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
+    - php: 7.2
+      env: DB=MYSQL CORE_RELEASE=3
+    - php: 7.3
+      env: DB=MYSQL CORE_RELEASE=3
 
 before_script:
   - composer self-update || true


### PR DESCRIPTION
As the master branch stands, the only working version of this module is for 7.1 since some locked dependencies don't run on 7.2 or 7.3. This change will ensure that we at least have some tests running.